### PR TITLE
Fix donations initializer configuration

### DIFF
--- a/lib/decidim/donations/generators/app_templates/initializer.rb
+++ b/lib/decidim/donations/generators/app_templates/initializer.rb
@@ -10,7 +10,7 @@ Decidim::Verifications.register_workflow(:donations) do |workflow|
   # workflow.time_between_renewals = 1.month
 end
 
-Decidim::Donations.credentials do
+Decidim::Donations.configure do |config|
   config.minimum_amount = 1
   config.verification_amount = 5 # if this config is omitted, defaults to minimum_amount
   config.default_amount = 10

--- a/lib/decidim/donations/generators/app_templates/initializer.rb
+++ b/lib/decidim/donations/generators/app_templates/initializer.rb
@@ -17,8 +17,8 @@ Decidim::Donations.configure do |config|
 
   config.provider = :paypal_express # currently only this one is supported
   config.credentials = {
-    login: Rails.application.secrets.donations[:login],
-    password: Rails.application.secrets.donations[:password],
-    signature: Rails.application.secrets.donations[:signature]
+    login: Rails.application.secrets.donations&.login,
+    password: Rails.application.secrets.donations&.password,
+    signature: Rails.application.secrets.donations&.signature
   }
 end


### PR DESCRIPTION
The generator was wrong. It wasn't creating a valid `config/initializers/decidim_donations.rb` file.